### PR TITLE
Feat: Simple x509 support for ApiClient

### DIFF
--- a/.openapi-generator-ignore
+++ b/.openapi-generator-ignore
@@ -21,3 +21,4 @@
 #docs/*.md
 # Then explicitly reverse the ignore rule for a single file:
 #!docs/README.md
+lib/Kubernetes/ApiClient.pm

--- a/cpanfile
+++ b/cpanfile
@@ -6,6 +6,7 @@ requires 'Module::Runtime';
 requires 'URI::Query';
 requires 'Module::Find';
 requires 'LWP::UserAgent';
+requires 'LWP::Protocol::https';
 requires 'Class::Accessor';
 
 on 'test' => sub {

--- a/examples/ssl_client.pl
+++ b/examples/ssl_client.pl
@@ -1,0 +1,26 @@
+use strict;
+use warnings;
+
+my $api_factory = Kubernetes::ApiFactory->new(
+    'base_url' => 'https://127.0.0.1:6443',
+    'ssl_opts' => {
+        # Disabling server ca validation
+        # SSL_verify_mode => IO::Socket::SSL::SSL_VERIFY_NONE,
+        # verify_hostname => 0,
+
+        SSL_use_cert => 1,
+        SSL_ca_file     => "/path/to/ca",
+        SSL_cert_file   => "/path/to/cert",
+        SSL_key_file    => "/path/to/key",
+    },
+);
+
+my $corev1_api = $api_factory->get_api('CoreV1');
+
+my $namespaceList = $corev1_api->list_namespace();
+
+printf "found %d namespaces:\n", scalar @{$namespaceList->items};
+printf "=====================\n", length @{$namespaceList->items};
+foreach my $namespace (@{$namespaceList->items}) {
+    printf "%s\n", $namespace->metadata->name;
+}

--- a/lib/Kubernetes/ApiClient.pm
+++ b/lib/Kubernetes/ApiClient.pm
@@ -51,10 +51,12 @@ sub new {
     }
 
     my (%args) = (
-        'ua' => LWP::UserAgent->new,
+        'ua' => LWP::UserAgent->new(
+            ssl_opts => $config->{ssl_opts},
+        ),
         'config' => $config,
     );
-  
+
     return bless \%args, $class;
 }
 

--- a/lib/Kubernetes/Configuration.pm
+++ b/lib/Kubernetes/Configuration.pm
@@ -110,7 +110,11 @@ sub new {
 	$p{access_token} //= '';
 
 	# base_url
-        $p{base_url} //= 'http://localhost';
+	$p{base_url} //= 'http://localhost';
+
+	$p{ssl_opts} //= {
+		verify_hostname => 1,
+	};
 
 	return bless \%p => $self;
 }


### PR DESCRIPTION
1. add a new parameter `ssl_opts` to `Configuration`
2. add a simple ssl example for connecting kubernetes cluster